### PR TITLE
Laravel 8.x and Php 8.0 Support, fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2.5|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -218,7 +218,7 @@ class Assets
      * @param  array  $assets
      * @return array
      */
-    protected function sortDependencies($assets = array(), $type)
+    protected function sortDependencies($assets = array(), $type = null)
     {
         $dependencyList = array();
 

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -86,7 +86,7 @@ class Assets
         $output        = '';
 
         foreach ($cssCollection as $key => $value) {
-            $output .= '<link rel="stylesheet" href="/'.$value.'">'."\n";
+            $output .= '<link rel="stylesheet" href="'.$value.'">'."\n";
         }
 
         return $output;
@@ -103,7 +103,7 @@ class Assets
         $output       = '';
 
         foreach ($jsCollection as $key => $value) {
-            $output .= '<script type="text/javascript" src="/'.$value.'"></script>'."\n";
+            $output .= '<script type="text/javascript" src="'.$value.'"></script>'."\n";
         }
 
         return $output;

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -8,13 +8,6 @@ class Assets
 {
 
     /**
-     * Regex pattern to match Bonsai json files.
-     *
-     * @var string
-     */
-    protected $bonsaiRegex = '/bonsai\.json$/i';
-
-    /**
      * @var Illuminate\Support\Collection
      */
     protected $collection;
@@ -50,10 +43,10 @@ class Assets
             foreach ($assets as $asset) {
                 $this->add($asset, $namespace);
             }
-        } elseif ($this->isAsset($assets)) {
-            $this->addAsset($assets, $namespace);
         } elseif ($this->isBonsai($assets)) {
             $this->parseBonsai($assets);
+        } elseif ($this->isAsset($assets)) {
+            $this->addAsset($assets, $namespace);
         }
 
         return $this;
@@ -93,7 +86,7 @@ class Assets
         $output        = '';
 
         foreach ($cssCollection as $key => $value) {
-            $output .= '<link rel="stylesheet" href="'.$value.'">'."\n";
+            $output .= '<link rel="stylesheet" href="/'.$value.'">'."\n";
         }
 
         return $output;
@@ -110,7 +103,7 @@ class Assets
         $output       = '';
 
         foreach ($jsCollection as $key => $value) {
-            $output .= '<script type="text/javascript" src="'.$value.'"></script>'."\n";
+            $output .= '<script type="text/javascript" src="/'.$value.'"></script>'."\n";
         }
 
         return $output;
@@ -157,7 +150,7 @@ class Assets
      */
     protected function isBonsai($asset)
     {
-        return preg_match($this->bonsaiRegex, $asset);
+        return preg_match('/bonsai\.json$/i', $asset);
     }
 
     /**

--- a/src/BonsaiServiceProvider.php
+++ b/src/BonsaiServiceProvider.php
@@ -21,16 +21,15 @@ class BonsaiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Blade::directive('bonsai', function($assetType) {
-            switch($assetType) {
-                case "'css'":
+        Blade::directive('bonsai', function($expression) {
+            eval("\$params = [$expression];");
+            switch($params[0]) {
+                case "add":
+                    return "<?php Bonsai::get()->add('$params[1]'".(isset($params[2])&&!empty($params[2])?",'$params[2]'":'').")".(isset($params[3])&&!empty($params[3])?"->dependsOn('$params[3]')":'')."; ?>";
+                case "css":
                     return "<?php echo Bonsai::get()->css(); ?>";
-                    break;
-
-                case "'js'":
-                return "<?php echo Bonsai::get()->js(); ?>";
-                    break;
-
+                case "js":
+                    return "<?php echo Bonsai::get()->js(); ?>";
                 default:
                     throw new Exception('Invalid asset type declared. Must be either "css" or "js".');
             }

--- a/src/BonsaiServiceProvider.php
+++ b/src/BonsaiServiceProvider.php
@@ -21,14 +21,11 @@ class BonsaiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Blade::directive('bonsai', function($expression) {
-            eval("\$params = [$expression];");
-            switch($params[0]) {
-                case "add":
-                    return "<?php Bonsai::get()->add('$params[1]'".(isset($params[2])&&!empty($params[2])?",'$params[2]'":'').")".(isset($params[3])&&!empty($params[3])?"->dependsOn('$params[3]')":'')."; ?>";
-                case "css":
+        Blade::directive('bonsai', function($assetType) {
+            switch($assetType) {
+                case "'css'":
                     return "<?php echo Bonsai::get()->css(); ?>";
-                case "js":
+                case "'js'":
                     return "<?php echo Bonsai::get()->js(); ?>";
                 default:
                     throw new Exception('Invalid asset type declared. Must be either "css" or "js".');


### PR DESCRIPTION
- Laravel 8.x and PHP 8.0 Support
- After [#6](https://github.com/caffeinated/bonsai/pull/6) files with extension .json are not used in parseBonsai() because stripos('file.bonsai.json', '.js') !== false, so answer first if is a json file
- ~~Added blade directive add~~ , ~~example~~
~~`@bonsai('add','files.bonsai.json')`~~
also removed unnecessary breaks; ~~and " ' " from cases~~
Closes [#7](https://github.com/caffeinated/bonsai/issues/7)
(sorry for my english)