### PR TITLE
Laravel 10.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2.5|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
For testing purposes,
Also at the rate the PRs are being merged the 10.x release is probably already here 😄😄

Maybe better??
```json
"illuminate/support": ">=6.0"
```